### PR TITLE
Daedalus-Mantis installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Daedalus - cryptocurrency wallet
 
 ## Automated build
 
-### CI/dev build scripts
+### Cardano CI/dev build scripts
 
 Platform-specific build scripts facilitate building Daedalus the way it is built
 by the IOHK CI:
@@ -16,8 +16,29 @@ by the IOHK CI:
 The result can be found at:
    - on OS X:    `${BUILD}/installers/dist/Daedalus-installer-*.pkg`
    - on WIndows: `${BUILD}/installers/daedalus-*-installer.exe`
+   
+### Mantis CI/dev build scripts
 
-### One-click build-fresh-daedalus scripts
+Platform-specific build scripts facilitate building Daedalus the way it is built
+by the IOHK CI:
+
+   - `scripts/mantis-build-installer-unix.sh     <DAEDALUS-VERSION> [OPTIONS..]`
+      - where OS is either `linux` (installer not currently supported) or `osx`
+      - facilitates installer upload to S3 via `--upload-s3`
+   - `scripts/mantis-build-installer-windows.bat <DAEDALUS-VERSION>`
+
+The resulting installer can be found at:
+   - on OS X:    `${BUILD}/installers/dist/Daedalus-installer-*.pkg`
+   - on Windows: `${BUILD}/installers/daedalus-win64-*-installer.exe`
+   
+Running the installer creates a desktop (on Windows) or docker (on MacOS) shortcut which can be used to start a background process running the Mantis client.
+
+The application installed can be uninstalled by:
+   - on OS X:    deleting the application located on `/Applications/Daedalus.app`
+   - on Windows: running `C:\Program Files\Daedalus\unistaller.exe`
+
+
+### Cardano one-click build-fresh-daedalus scripts
 
 These rely on the scripts from the previous section, but also go to a certain
 trouble to ensure that dependencies are installed, and even check out a fresh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# daedalus
-Daedalus - cryptocurrency wallet
+# daedalus-mantis
+[Daedalus - cryptocurrency wallet](https://github.com/input-output-hk/daedalus) packed with the [Mantis client](https://github.com/input-output-hk/mantis).
 
 ## Automated build
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
 build: off
 
 cache:
-  - C:\sr -> installers/cardano-installer.cabal
+  - C:\sr -> installers/installer.cabal
   - C:\sr -> installers/stack.yaml
 
 install:

--- a/installers/MantisInstaller.hs
+++ b/installers/MantisInstaller.hs
@@ -5,7 +5,7 @@ import           Turtle
 import           Turtle.Line          (unsafeTextToLine)
 
 import qualified MantisWindowsInstaller
-import qualified MacInstaller
+import qualified MantisMacInstaller
 
 
 main :: IO ()
@@ -13,6 +13,6 @@ main = do
   echo $ unsafeTextToLine . T.pack $ "Generating installer for " <>  os <> "-" <> arch
   case os of
     "linux" -> echo "No installer yet"
-    "darwin" -> echo "No installer yet"
+    "darwin" -> MantisMacInstaller.main
     "mingw32" -> MantisWindowsInstaller.main
     _ -> fail "No installer available for this platform."

--- a/installers/MantisInstaller.hs
+++ b/installers/MantisInstaller.hs
@@ -1,0 +1,18 @@
+import           Data.Text as T
+import           Data.Monoid ((<>))
+import           System.Info
+import           Turtle
+import           Turtle.Line          (unsafeTextToLine)
+
+import qualified MantisWindowsInstaller
+import qualified MacInstaller
+
+
+main :: IO ()
+main = do
+  echo $ unsafeTextToLine . T.pack $ "Generating installer for " <>  os <> "-" <> arch
+  case os of
+    "linux" -> echo "No installer yet"
+    "darwin" -> echo "No installer yet"
+    "mingw32" -> MantisWindowsInstaller.main
+    _ -> fail "No installer available for this platform."

--- a/installers/MantisMacInstaller.hs
+++ b/installers/MantisMacInstaller.hs
@@ -1,0 +1,99 @@
+module MantisMacInstaller where
+
+---
+--- An overview of Mac .pkg internals:  http://www.peachpit.com/articles/article.aspx?p=605381&seqNum=2
+---
+
+import           Control.Monad      (unless)
+import           Data.Maybe         (fromMaybe)
+import           Data.Monoid        ((<>))
+import qualified Data.Text          as T
+import           System.Directory
+import           System.Environment (lookupEnv)
+import           Turtle             (ExitCode (..), echo, procs, shell, shells, cptree, fromText, touch)
+import           Turtle.Line        (unsafeTextToLine)
+
+import           RewriteLibs        (chain)
+
+import           MacInstaller
+
+main :: IO ()
+main = do
+  version <- fromMaybe "dev" <$> lookupEnv "DAEDALUS_VERSION"
+
+  let appRoot = "../release/darwin-x64/Daedalus-darwin-x64/Daedalus.app"
+      dir     = appRoot <> "/Contents/MacOS"
+      -- resDir  = appRoot <> "/Contents/Resources"
+      pkg     = "dist/Daedalus-installer-" <> version <> ".pkg"
+  createDirectoryIfMissing False "dist"
+
+  procs "iconutil" ["--convert", "icns", "--output", T.pack dir <> "/../Resources/electron.icns", "icons/electron.iconset"] mempty
+
+  echo "Preparing files ..."
+  cptree "mantis.app" (fromText $ T.pack $ dir <> "/mantis.app")
+  touch $ fromText $ T.pack $ dir <> "/mantis.app/Contents/Java/mantis.log"
+  run "chmod" ["a+w", T.pack (dir <> "/mantis.app/Contents/Java/mantis.log")]
+  copyFile "wallet-topology.yaml" (dir <> "/wallet-topology.yaml")
+  copyFile "log-config-prod.yaml" (dir <> "/log-config-prod.yaml")
+  copyFile "data/ip-dht-mappings" (dir <> "/ip-dht-mappings")
+  copyFile "data/ip-dht-mappings" (dir <> "/ip-dht-mappings")
+  copyFile "build-certificates-unix.sh" (dir <> "/build-certificates-unix.sh")
+  copyFile "ca.conf"     (dir <> "/ca.conf")
+  copyFile "server.conf" (dir <> "/server.conf")
+  copyFile "client.conf" (dir <> "/client.conf")
+
+  -- Rewrite libs paths and bundle them
+  _ <- chain dir $ fmap T.pack [dir <> "/mantis.app/Contents/MacOS/mantis", dir <> "/mantis.app/Contents/MacOS/mantis"]
+
+  -- Prepare launcher
+  de <- doesFileExist (dir <> "/Frontend")
+  unless de $ renameFile (dir <> "/Daedalus") (dir <> "/Frontend")
+  run "chmod" ["+x", T.pack (dir <> "/Frontend")]
+  writeFile (dir <> "/Daedalus") $ unlines
+    [ "#!/usr/bin/env bash"
+    , "cd \"$(dirname $0)\""
+    , "mkdir -p \"$HOME/Library/Application Support/Daedalus/Secrets-0.6\""
+    , "./mantis.app/Contents/MacOS/mantis"
+    --FIXME: Start the Daedalus wallet
+    ]
+  run "chmod" ["+x", T.pack (dir <> "/Daedalus")]
+
+  let pkgargs =
+       [ "--identifier"
+       , "org.daedalus.pkg"
+       , "--scripts", "data/scripts"
+       , "--component"
+       , "../release/darwin-x64/Daedalus-darwin-x64/Daedalus.app"
+       , "--install-location"
+       , "/Applications"
+       , "dist/temp.pkg"
+       ]
+  run "pkgbuild" pkgargs
+
+  let productargs =
+       [ "--product"
+       , "data/plist"
+       , "--package"
+       , "dist/temp.pkg"
+       , "dist/temp2.pkg"
+       ]
+  run "productbuild" productargs
+
+  isPullRequest <- fromMaybe "true" <$> lookupEnv "TRAVIS_PULL_REQUEST"
+  if isPullRequest == "false" then do
+    -- Sign the installer with a special macOS dance
+    run "security" ["create-keychain", "-p", "travis", "macos-build.keychain"]
+    run "security" ["default-keychain", "-s", "macos-build.keychain"]
+    exitcode <- shell "security import macos.p12 -P \"$CERT_PASS\" -k macos-build.keychain -T `which productsign`" mempty
+    unless (exitcode == ExitSuccess) $ error "Signing failed"
+    run "security" ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", "travis", "macos-build.keychain"]
+    run "security" ["unlock-keychain", "-p", "travis", "macos-build.keychain"]
+    shells ("productsign --sign \"Developer ID Installer: Input Output HK Limited (89TW38X994)\" --keychain macos-build.keychain dist/temp2.pkg " <> T.pack pkg) mempty
+  else do
+    echo "Pull request, not signing the installer."
+    run "cp" ["dist/temp2.pkg", T.pack pkg]
+
+  run "rm" ["dist/temp.pkg"]
+  run "rm" ["dist/temp2.pkg"]
+
+  echo $ "Generated " <> unsafeTextToLine (T.pack pkg)

--- a/installers/MantisMacInstaller.hs
+++ b/installers/MantisMacInstaller.hs
@@ -27,6 +27,7 @@ main = do
       pkg     = "dist/Daedalus-installer-" <> version <> ".pkg"
   createDirectoryIfMissing False "dist"
 
+  echo "Creating icons ..."
   procs "iconutil" ["--convert", "icns", "--output", T.pack dir <> "/../Resources/electron.icns", "icons/electron.iconset"] mempty
 
   echo "Preparing files ..."

--- a/installers/MantisWindowsInstaller.hs
+++ b/installers/MantisWindowsInstaller.hs
@@ -50,7 +50,6 @@ mantisWriteInstallerNSIS fullVersion = do
         --FIXME: Make Mantis logs location configurable so as to have them be in this Logs folder
         createDirectory "$APPDATA\\Daedalus\\Logs"
         createShortcut "$DESKTOP\\Daedalus.lnk" daedalusShortcut
-        file [] "log-config-prod.yaml"
         file [] "data\\ip-dht-mappings"
         file [] "version.txt"
         file [] "build-certificates-win64.bat"
@@ -59,7 +58,6 @@ mantisWriteInstallerNSIS fullVersion = do
         file [] "client.conf"
         file [] "wallet-topology.yaml"
         writeFileLines "$INSTDIR\\daedalus.bat" (map str mantisLauncherScript)
-        file [Recursive] "dlls\\"
         file [Recursive] "libressl\\"
         file [Recursive] "..\\release\\win32-x64\\Daedalus-win32-x64\\"
         setOutPath "$INSTDIR\\mantis\\"

--- a/installers/MantisWindowsInstaller.hs
+++ b/installers/MantisWindowsInstaller.hs
@@ -1,0 +1,120 @@
+module MantisWindowsInstaller where
+
+import qualified Data.List          as L
+import           Data.Maybe         (fromJust, fromMaybe)
+import           Data.Monoid        ((<>))
+import           Development.NSIS
+import           System.Environment (lookupEnv)
+import           Turtle             (ExitCode (..), echo, proc, procs)
+
+import           WindowsInstaller
+
+mantisLauncherScript :: [String]
+mantisLauncherScript =
+  [ "@echo off"
+  , "SET DAEDALUS_DIR=%~dp0"
+  , "start /D \"%DAEDALUS_DIR%mantis\" mantis.exe " --Start the Mantis client
+--  , "start /D \"%DAEDALUS_DIR%\" Daedalus.exe " --Start the Daedalus wallet (FIXME: temporarily disabled as the Mantis client can't properly connect with it yet)
+  ]
+
+mantisWriteInstallerNSIS :: String -> IO ()
+mantisWriteInstallerNSIS fullVersion = do
+  tempDir <- fmap fromJust $ lookupEnv "TEMP"
+  writeFile "daedalus.nsi" $ nsis $ do
+    _ <- constantStr "Version" (str fullVersion)
+    name "Daedalus ($Version)"                  -- The name of the installer
+    outFile "daedalus-win64-$Version-installer.exe"           -- Where to produce the installer
+    unsafeInjectGlobal $ "!define MUI_ICON \"icons\\64x64.ico\""
+    unsafeInjectGlobal $ "!define MUI_HEADERIMAGE"
+    unsafeInjectGlobal $ "!define MUI_HEADERIMAGE_BITMAP \"icons\\installBanner.bmp\""
+    unsafeInjectGlobal $ "!define MUI_HEADERIMAGE_RIGHT"
+    unsafeInjectGlobal $ "VIProductVersion " <> (L.intercalate "." $ parseVersion fullVersion)
+    unsafeInjectGlobal $ "VIAddVersionKey \"ProductVersion\" " <> fullVersion
+    unsafeInjectGlobal "Unicode true"
+    requestExecutionLevel Highest
+    unsafeInjectGlobal "!addplugindir \"nsis_plugins\\liteFirewall\\bin\""
+
+    installDir "$PROGRAMFILES64\\Daedalus"                   -- Default installation directory...
+    installDirRegKey HKLM "Software/Daedalus" "Install_Dir"  -- ...except when already installed.
+
+    page Directory                   -- Pick where to install
+    constant "INSTALLEDAT" $ readRegStr HKLM "Software/Daedalus" "Install_Dir"
+    onPagePre Directory (iff_ (strLength "$INSTALLEDAT" %/= 0) $ abort "")
+
+    page InstFiles                   -- Give a progress bar while installing
+
+    _ <- section "" [Required] $ do
+        setOutPath "$INSTDIR"        -- Where to install files in this section
+        writeRegStr HKLM "Software/Daedalus" "Install_Dir" "$INSTDIR" -- Used by launcher batch script
+        createDirectory "$APPDATA\\Daedalus\\Secrets-0.6"
+        --FIXME: Make Mantis logs location configurable so as to have them be in this Logs folder
+        createDirectory "$APPDATA\\Daedalus\\Logs"
+        createShortcut "$DESKTOP\\Daedalus.lnk" daedalusShortcut
+        file [] "log-config-prod.yaml"
+        file [] "data\\ip-dht-mappings"
+        file [] "version.txt"
+        file [] "build-certificates-win64.bat"
+        file [] "ca.conf"
+        file [] "server.conf"
+        file [] "client.conf"
+        file [] "wallet-topology.yaml"
+        writeFileLines "$INSTDIR\\daedalus.bat" (map str mantisLauncherScript)
+        file [Recursive] "dlls\\"
+        file [Recursive] "libressl\\"
+        file [Recursive] "..\\release\\win32-x64\\Daedalus-win32-x64\\"
+        setOutPath "$INSTDIR\\mantis\\"
+        file [Recursive] "mantis\\"
+        setOutPath "$INSTDIR"
+
+        mapM_ unsafeInject
+          [ "liteFirewall::AddRule \"$INSTDIR\\mantis\\mantis.exe\" \"Mantis Node\""
+          , "Pop $0"
+          , "DetailPrint \"liteFirewall::AddRule: $0\""
+          ]
+
+        execWait "build-certificates-win64.bat \"$INSTDIR\" >\"%APPDATA%\\Daedalus\\Logs\\build-certificates.log\" 2>&1"
+
+        -- Uninstaller
+        writeRegStr HKLM "Software/Microsoft/Windows/CurrentVersion/Uninstall/Daedalus" "InstallLocation" "$INSTDIR\\Daedalus"
+        writeRegStr HKLM "Software/Microsoft/Windows/CurrentVersion/Uninstall/Daedalus" "Publisher" "Eureka Solutions LLC"
+        writeRegStr HKLM "Software/Microsoft/Windows/CurrentVersion/Uninstall/Daedalus" "ProductVersion" (str fullVersion)
+        writeRegStr HKLM "Software/Microsoft/Windows/CurrentVersion/Uninstall/Daedalus" "VersionMajor" (str . (!! 0). parseVersion $ fullVersion)
+        writeRegStr HKLM "Software/Microsoft/Windows/CurrentVersion/Uninstall/Daedalus" "VersionMinor" (str . (!! 1). parseVersion $ fullVersion)
+        writeRegStr HKLM "Software/Microsoft/Windows/CurrentVersion/Uninstall/Daedalus" "DisplayName" "Daedalus"
+        writeRegStr HKLM "Software/Microsoft/Windows/CurrentVersion/Uninstall/Daedalus" "DisplayVersion" (str fullVersion)
+        writeRegStr HKLM "Software/Microsoft/Windows/CurrentVersion/Uninstall/Daedalus" "UninstallString" "\"$INSTDIR/uninstall.exe\""
+        writeRegStr HKLM "Software/Microsoft/Windows/CurrentVersion/Uninstall/Daedalus" "QuietUninstallString" "\"$INSTDIR/uninstall.exe\" /S"
+        writeRegDWORD HKLM "Software/Microsoft/Windows/CurrentVersion/Uninstall/Daedalus" "NoModify" 1
+        writeRegDWORD HKLM "Software/Microsoft/Windows/CurrentVersion/Uninstall/Daedalus" "NoRepair" 1
+        file [] $ (str $ tempDir <> "\\uninstall.exe")
+
+    _ <- section "Start Menu Shortcuts" [] $ do
+        createDirectory "$SMPROGRAMS/Daedalus"
+        createShortcut "$SMPROGRAMS/Daedalus/Uninstall Daedalus.lnk"
+          [Target "$INSTDIR/uninstall.exe", IconFile "$INSTDIR/uninstall.exe", IconIndex 0]
+        createShortcut "$SMPROGRAMS/Daedalus/Daedalus.lnk" daedalusShortcut
+    return ()
+
+main :: IO ()
+main = do
+  echo "Writing version.txt"
+  version <- fmap (fromMaybe "dev") $ lookupEnv "APPVEYOR_BUILD_VERSION"
+  let fullVersion = version <> ".0"
+  writeFile "version.txt" fullVersion
+
+  signFile "mantis\\mantis.exe"
+
+  echo "Writing uninstaller.nsi"
+  writeUninstallerNSIS fullVersion
+  signUninstaller
+
+  --FIXME: mt.exe location was changed to match the one in a Windows 10 machine, this should be generalized to be dependant on the machine ran
+  echo "Adding permissions manifest to mantis.exe"
+  procs "C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.15063.0\\x64\\mt.exe" ["-manifest", "mantis.exe.manifest", "-outputresource:mantis\\mantis.exe;#1"] mempty
+
+  echo "Writing daedalus.nsi"
+  mantisWriteInstallerNSIS fullVersion
+
+  echo "Generating NSIS installer daedalus-win64-installer.exe"
+  procs "C:\\Program Files (x86)\\NSIS\\makensis" ["daedalus.nsi"] mempty
+  signFile ("daedalus-win64-" <> fullVersion <> "-installer.exe")

--- a/installers/installer.cabal
+++ b/installers/installer.cabal
@@ -38,6 +38,8 @@ executable mantis-make-installer
   main-is:             MantisInstaller.hs
   other-modules:       MantisMacInstaller
                      , MantisWindowsInstaller
+                     , MacInstaller
+                     , WindowsInstaller
                      , RewriteLibs
                      , Launcher
   build-depends:       base

--- a/installers/installer.cabal
+++ b/installers/installer.cabal
@@ -36,7 +36,8 @@ executable make-installer
 
 executable mantis-make-installer
   main-is:             MantisInstaller.hs
-  other-modules:       MantisWindowsInstaller
+  other-modules:       MantisMacInstaller
+                     , MantisWindowsInstaller
                      , RewriteLibs
                      , Launcher
   build-depends:       base

--- a/installers/installer.cabal
+++ b/installers/installer.cabal
@@ -1,6 +1,6 @@
-name:                cardano-installer
+name:                installer
 version:             0.1.0.0
-synopsis:            Cardano Installer
+synopsis:            Cardano and Mantis Installer
 description:         Please see README.md
 license:             MIT
 author:              Serokell
@@ -14,6 +14,29 @@ executable make-installer
   main-is:             Installer.hs
   other-modules:       MacInstaller
                      , WindowsInstaller
+                     , RewriteLibs
+                     , Launcher
+  build-depends:       base
+                     , filepath
+                     , text
+                     , Glob
+                     , nsis
+                     , turtle
+                     , directory
+                     , temporary
+                     , megaparsec
+
+  default-language:    Haskell2010
+  ghc-options:         -threaded -rtsopts
+                       -Wall
+                       -fno-warn-orphans
+                       -with-rtsopts=-N
+                       -O2
+  default-extensions: OverloadedStrings
+
+executable mantis-make-installer
+  main-is:             MantisInstaller.hs
+  other-modules:       MantisWindowsInstaller
                      , RewriteLibs
                      , Launcher
   build-depends:       base

--- a/installers/mantis.exe.manifest
+++ b/installers/mantis.exe.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel level="highestAvailable" uiAccess="false"/>
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+</assembly>

--- a/scripts/mantis-build-installer-unix.sh
+++ b/scripts/mantis-build-installer-unix.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# DEPENDENCIES (binaries should be in PATH):
+#   0. 'git'
+#   1. 'curl'
+#   2. 'nix-shell'
+#   3. 'stack'
+
+set -e
+
+usage() {
+    test -z "$1" || { echo "ERROR: $*" >&2; echo >&2; }
+    cat >&2 <<EOF
+  Usage:
+    $0 DAEDALUS-VERSION OPTIONS*
+
+  Build a Daedalus installer.
+
+  Options:
+    --fast-impure             Fast, impure, incremental build
+    --build-id BUILD-NO       Identifier of the build; defaults to '0'
+
+    --travis-pr PR-ID         Travis pull request id we're building
+    --nix-path NIX-PATH       NIX_PATH value
+
+    --upload-s3               Upload the installer to S3
+    --test-install            Test the installer for installability
+
+    --verbose                 Verbose operation
+    --quiet                   Disable verbose operation
+    
+EOF
+    test -z "$1" || exit 1
+}
+
+arg2nz() { test $# -ge 2 -a ! -z "$2" || usage "empty value for" $1; }
+fail() { echo "ERROR: $*" >&2; exit 1; }
+retry() {
+        local tries=$1; arg2nz "iteration count" $1; shift
+        for i in $(seq 1 ${tries})
+        do if "$@"
+           then return 0
+           fi
+           sleep 5s
+        done
+        fail "persistent failure to exec:  $*"
+}
+
+###
+### Argument processing
+###
+fast_impure=
+verbose=true
+build_id=0
+travis_pr=true
+upload_s3=
+test_install=
+
+daedalus_version="$1"; arg2nz "daedalus version" $1; shift
+mantis_location="/Users/dev/Documents/mantis-client/mantis/target/jdkpackager/bundles/mantis.app"
+
+case "$(uname -s)" in
+        Darwin ) os=osx;   key=macos-3.p12;;
+        Linux )  os=linux; key=linux.p12;;
+        * )     usage "Unsupported OS: $(uname -s)";;
+esac
+
+set -u ## Undefined variable firewall enabled
+while test $# -ge 1
+do case "$1" in
+           --fast-impure )                               fast_impure=true;;
+           --build-id )       arg2nz "build identifier" $2;    build_id="$2"; shift;;
+           --travis-pr )      arg2nz "Travis pull request id" $2;
+                                                           travis_pr="$2"; shift;;
+           --nix-path )       arg2nz "NIX_PATH value" $2;
+                                                     export NIX_PATH="$2"; shift;;
+           --upload-s3 )                                   upload_s3=t;;
+           --test-install )                             test_install=t;;
+
+           ###
+           --verbose )        echo "$0: --verbose passed, enabling verbose operation"
+                                                             verbose=t;;
+           --quiet )          echo "$0: --quiet passed, disabling verbose operation"
+                                                             verbose=;;
+           --help )           usage;;
+           "--"* )            usage "unknown option: '$1'";;
+           * )                break;; esac
+   shift; done
+
+set -e
+if test -n "${verbose}"
+then set -x
+fi
+
+mkdir -p ~/.local/bin
+
+export PATH=$HOME/.local/bin:$PATH
+export DAEDALUS_VERSION=${daedalus_version}.${build_id}
+if [ -n "${NIX_SSL_CERT_FILE-}" ]; then export SSL_CERT_FILE=$NIX_SSL_CERT_FILE; fi
+
+# FIXME: The Mantis client is moved from a local folder, this should be changed with downloading the client
+test -d installers/mantis.app/ -a -n "${fast_impure}" || {
+        rm -rf installers/mantis.app/
+        cp -r "${mantis_location}" installers
+}
+
+test "$(find node_modules/ | wc -l)" -gt 100 -a -n "${fast_impure}" ||
+        nix-shell --run "npm install"
+
+test -d "release/darwin-x64/Daedalus-darwin-x64" -a -n "${fast_impure}" || {
+        nix-shell --run "npm run package -- --icon installers/icons/256x256.png"
+        echo "Size of Electron app is $(du -sh release)"
+}
+
+test -n "$(which stack)"     -a -n "${fast_impure}" ||
+        retry 5 bash -c "curl -L https://www.stackage.org/stack/${os}-x86_64 | \
+                         tar xz --strip-components=1 -C ~/.local/bin"
+
+cd installers
+    if test "${travis_pr}" = "false" -a "${os}" != "linux" # No Linux keys yet.
+    then retry 5 nix-shell -p awscli --run "aws s3 cp --region eu-central-1 s3://iohk-private/${key} macos.p12"
+    fi
+    retry 5 $(nix-build -j 2)/bin/mantis-make-installer
+    mkdir -p dist
+    if test -n "${upload_s3}"
+    then
+            echo "$0: --upload-s3 passed, will upload the installer to S3";
+            retry 5 nix-shell -p awscli --run "aws s3 cp 'dist/Daedalus-installer-${DAEDALUS_VERSION}.pkg' s3://daedalus-internal/ --acl public-read"
+    fi
+    if test -n "${test_install}"
+    then echo "$0:  --test-install passed, will test the installer for installability";
+         case ${os} in
+                 osx )   sudo installer -dumplog -verbose -target / -pkg "dist/Daedalus-installer-${DAEDALUS_VERSION}.pkg";;
+                 linux ) echo "WARNING: installation testing not implemented on Linux" >&2;; esac; fi
+cd ..
+
+ls -la installers/dist
+
+exit 0

--- a/scripts/mantis-build-installer-unix.sh
+++ b/scripts/mantis-build-installer-unix.sh
@@ -11,7 +11,7 @@ usage() {
     test -z "$1" || { echo "ERROR: $*" >&2; echo >&2; }
     cat >&2 <<EOF
   Usage:
-    $0 DAEDALUS-VERSION OPTIONS*
+    $0 DAEDALUS-VERSION MANTIS-LOCATION OPTIONS*
 
   Build a Daedalus installer.
 
@@ -56,7 +56,7 @@ upload_s3=
 test_install=
 
 daedalus_version="$1"; arg2nz "daedalus version" $1; shift
-mantis_location="/Users/dev/Documents/mantis-client/mantis/target/jdkpackager/bundles/mantis.app"
+mantis_location="$1"; arg2nz "mantis package location" $1; shift
 
 case "$(uname -s)" in
         Darwin ) os=osx;   key=macos-3.p12;;

--- a/scripts/mantis-build-installer-win64.bat
+++ b/scripts/mantis-build-installer-win64.bat
@@ -6,30 +6,21 @@ rem   4. Windows SDK
 rem
 rem   installer dev mode:  set SKIP_TO_FRONTEND/SKIP_TO_INSTALLER
 
-set MIN_CARDANO_BYTES=50000000
 set LIBRESSL_VERSION=2.5.3
 set CURL_VERSION=7.54.0
-set CARDANO_BRANCH_DEFAULT=cardano-sl-0.6-staging
-set DAEDALUS_VERSION_DEFAULT=local-dev-build-%CARDANO_BRANCH_DEFAULT%
-
-set DAEDALUS_VERSION=%1
-@if [%DAEDALUS_VERSION%]==[] (@echo WARNING: DAEDALUS_VERSION [argument #1] was not provided, defaulting to %DAEDALUS_VERSION_DEFAULT%
-    set DAEDALUS_VERSION=%DAEDALUS_VERSION_DEFAULT%);
-set CARDANO_BRANCH=%2
-@if [%CARDANO_BRANCH%]==[]   (@echo WARNING: CARDANO_BRANCH [argument #2] was not provided, defaulting to %CARDANO_BRANCH_DEFAULT%
-    set CARDANO_BRANCH=%CARDANO_BRANCH_DEFAULT%);
+set DAEDALUS_VERSION=local-dev-build-mantis
 
 set CURL_URL=https://bintray.com/artifact/download/vszakats/generic/curl-%CURL_VERSION%-win64-mingw.7z
 set CURL_BIN=curl-%CURL_VERSION%-win64-mingw\bin
 set NSISVER=3.02.1
 set NSIS_URL=https://downloads.sourceforge.net/project/nsis/NSIS%%203/%NSISVER%/nsis-%NSISVER%-setup.exe
 set NSIS_PATCH_URL=https://downloads.sourceforge.net/project/nsis/NSIS%%203/%NSISVER%/nsis-%NSISVER%-strlen_8192.zip
-set CARDANO_URL=https://ci.appveyor.com/api/projects/jagajaga/cardano-sl/artifacts/CardanoSL.zip?branch=%CARDANO_BRANCH%
 set LIBRESSL_URL=https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-%LIBRESSL_VERSION%-windows.zip
-set DLLS_URL=https://s3.eu-central-1.amazonaws.com/cardano-sl-testing/DLLs.zip
+
+rem Location of the mantis client with the embedded JVM (FIXME: this should be changed to be later downloaded)
+set MANTIS_LOCATION=..\etc-client\target\jdkpackager\bundles\mantis
 
 @echo Building Daedalus version:  %DAEDALUS_VERSION%
-@echo ..with Cardano branch:      %CARDANO_BRANCH%
 @echo ..with LibreSSL version:    %LIBRESSL_VERSION%
 @echo .
 
@@ -73,29 +64,10 @@ call npm install
 @if %errorlevel% neq 0 (@echo FAILED: npm install
     exit /b 1)
 
-@echo Obtaining Cardano from branch %CARDANO_BRANCH%
-rmdir /s/q node_modules\daedalus-client-api 2>nul
-mkdir      node_modules\daedalus-client-api
-
-pushd node_modules\daedalus-client-api
-    del /f CardanoSL.zip 2>nul
-    ..\..\curl --location %CARDANO_URL% -o CardanoSL.zip
-    @if %errorlevel% neq 0 (@echo FAILED: couldn't obtain the cardano-sl package
-	popd & exit /b 1)
-    @for /F "usebackq" %%A in ('CardanoSL.zip') do set size=%%~zA
-    if %size% lss %MIN_CARDANO_BYTES% (@echo FAILED: CardanoSL.zip is too small: threshold=%MIN_CARDANO_BYTES%, actual=%size% bytes
-        popd & exit /b 1)
-
-    7z x CardanoSL.zip -y
-    @if %errorlevel% neq 0 (@echo FAILED: 7z x CardanoSL.zip -y
-	popd & exit /b 1)
-    del CardanoSL.zip
-popd
-
-move   node_modules\daedalus-client-api\log-config-prod.yaml installers\log-config-prod.yaml
-move   node_modules\daedalus-client-api\cardano-node.exe     installers\
-move   node_modules\daedalus-client-api\cardano-launcher.exe installers\
-del /f node_modules\daedalus-client-api\*.exe
+rem Move mantis client location to installers (FIXME: should be replaced with downloading and uncompressing it)
+@echo Moving Mantis from %MANTIS_LOCATION%
+rmdir /s/q installers\mantis 2>nul
+xcopy   %MANTIS_LOCATION% installers\mantis\ /s
 
 :build_frontend
 @echo Packaging frontend
@@ -126,33 +98,19 @@ pushd installers
 	exit /b 1)
     del stack.zip
 
-    @echo Copying DLLs
-    @rem TODO: get rocksdb from rocksdb-haskell
-    rmdir /s/q DLLs 2>nul
-    mkdir      DLLs
-    pushd      DLLs
-        ..\..\curl --location %DLLS_URL% -o DLLs.zip
-        @if %errorlevel% neq 0 (@echo FAILED: couldn't obtain CardanoSL DLL package
-		exit /b 1)
-        7z x DLLs.zip
-        @if %errorlevel% neq 0 (@echo FAILED: 7z x DLLs.zip
-		popd & popd & exit /b 1)
-        del DLLs.zip
-    popd
-
     @echo Building the installer
     stack setup --no-reinstall > nul
     @if %errorlevel% neq 0 (@echo FAILED: stack setup --no-reinstall
 	exit /b 1)
 
 :build_installer
-    call ..\scripts\appveyor-retry call stack --no-terminal build -j 2 --exec make-installer
+    call ..\scripts\appveyor-retry call stack --no-terminal build -j 2 --exec mantis-make-installer
     @if %errorlevel% equ 0 goto :built
 
-    @echo FATAL: persistent failure while building installer with:  call stack --no-terminal build -j 2 --exec make-installer
+    @echo FATAL: persistent failure while building installer with:  call stack --no-terminal build -j 2 --exec mantis-make-installer
     exit /b 1
 :built
-@echo SUCCESS: call stack --no-terminal build -j 2 --exec make-installer
+@echo SUCCESS: call stack --no-terminal build -j 2 --exec mantis-make-installer
 popd
 
 @dir /b/s installers\daedalus*

--- a/scripts/mantis-build-installer-win64.bat
+++ b/scripts/mantis-build-installer-win64.bat
@@ -17,8 +17,10 @@ set NSIS_URL=https://downloads.sourceforge.net/project/nsis/NSIS%%203/%NSISVER%/
 set NSIS_PATCH_URL=https://downloads.sourceforge.net/project/nsis/NSIS%%203/%NSISVER%/nsis-%NSISVER%-strlen_8192.zip
 set LIBRESSL_URL=https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-%LIBRESSL_VERSION%-windows.zip
 
-rem Location of the mantis client with the embedded JVM (FIXME: this should be changed to be later downloaded)
-set MANTIS_LOCATION=..\etc-client\target\jdkpackager\bundles\mantis
+rem Location of the mantis client with the embedded JVM is configurable
+set MANTIS_LOCATION=%1
+@if [%MANTIS_LOCATION%]==[]   (@echo ERROR: MANTIS_LOCATION [argument #1] was not provided, terminating installation
+    exit /b 1);
 
 @echo Building Daedalus version:  %DAEDALUS_VERSION%
 @echo ..with LibreSSL version:    %LIBRESSL_VERSION%


### PR DESCRIPTION
Includes installers for integrating the Daedalus wallet with the Mantis client. Currently the installer generated only starts the Mantis client, this will be changed once the Mantis-Daedalus integration is done.

Both Windows and Mac installers have a configurable local location of the Mantis package, which should be generated using `sbt jdkPackager:packageBin` from the branch `feature/daedalusInstaller` (with a current [open PR](https://github.com/input-output-hk/mantis/pull/331)).